### PR TITLE
Fix warning message from simple_form 3.1

### DIFF
--- a/lib/judge/simple_form.rb
+++ b/lib/judge/simple_form.rb
@@ -6,7 +6,7 @@ module SimpleForm
     module Judge
       include ::Judge::Html
 
-      def judge
+      def judge(wrapper_options = nil)
         if has_judge?
           input_html_options.deep_merge!(attrs_for(object, attribute_name))
         end


### PR DESCRIPTION
Small change that eliminates warning messages when using simple_form 3.1.
