### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Do this in your Gemfile:
 gem 'judge-simple_form'
 ```
 
-Remember to setup Judge in your SimpleForm initializer:
+Remember to setup Judge in your SimpleForm initializer. Put `b.use :judge` above `b.use :input` or `b.use :input_label`:
 
 ```ruby
 config.wrappers do |b|

--- a/spec/judge-simple_form_spec.rb
+++ b/spec/judge-simple_form_spec.rb
@@ -15,7 +15,7 @@ describe Judge::SimpleForm do
     ActionView::Base.new(nil, {}, UsersController.new)
   end
   let(:builder) do
-    SimpleForm::FormBuilder.new(:user, User.new, template, {}, nil)
+    SimpleForm::FormBuilder.new(:user, User.new, template, {})
   end
 
   it 'adds data attribute when :validate option is true' do


### PR DESCRIPTION
Simple form cannot use :judge if :input or :input_label is declared above it. Specs fail too. So the instruction to put :judge before :input is added to the `readme`.

It looks like Simple Form 3 accepts four argument instead of five. So the extra argument is also removed.