### PR TITLE
Update simple_form.rb

### DIFF
--- a/lib/judge/simple_form.rb
+++ b/lib/judge/simple_form.rb
@@ -6,7 +6,7 @@ module SimpleForm
     module Judge
       include ::Judge::Html
 
-      def judge
+      def judge(wrapper_options)
         if has_judge?
           input_html_options.deep_merge!(attrs_for(object, attribute_name))
         end


### PR DESCRIPTION
@joecorcoran

DEPRECATION WARNING: judge method now accepts a wrapper_options argument. The method definition without the argument is deprecated and will be removed in the next Simple Form version. Change your code from:
def judge
to
def judge(wrapper_options)
See plataformatec/simple_form#997 for more information.
(called from render at ........../bundler/gems/simple_form-6c9e69b22f63/lib/simple_form/wrappers/leaf.rb:15)

This just solve the deprecation warning!
We should merge it