### PR TITLE
update for newer simple_form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/lib/judge/simple_form.rb
+++ b/lib/judge/simple_form.rb
@@ -6,7 +6,7 @@ module SimpleForm
     module Judge
       include ::Judge::Html
 
-      def judge
+      def judge(wrapper_options = nil)
         if has_judge?
           input_html_options.deep_merge!(attrs_for(object, attribute_name))
         end

--- a/spec/judge-simple_form_spec.rb
+++ b/spec/judge-simple_form_spec.rb
@@ -15,7 +15,7 @@ describe Judge::SimpleForm do
     ActionView::Base.new(nil, {}, UsersController.new)
   end
   let(:builder) do
-    SimpleForm::FormBuilder.new(:user, User.new, template, {}, nil)
+    SimpleForm::FormBuilder.new(:user, User.new, template, {})
   end
 
   it 'adds data attribute when :validate option is true' do


### PR DESCRIPTION
- simple_form throws a deprecation error if the arity of the `#judge` method is 0 (https://github.com/plataformatec/simple_form/pull/997)
- `SimpleForm::Formbuilder` only takes 4 args
- Added `.gitignore` for sanity