### PR TITLE
Updating the simple_form  custom input definition

### DIFF
--- a/lib/judge/simple_form.rb
+++ b/lib/judge/simple_form.rb
@@ -6,7 +6,7 @@ module SimpleForm
     module Judge
       include ::Judge::Html
 
-      def judge
+      def judge(wrapper_options)
         if has_judge?
           input_html_options.deep_merge!(attrs_for(object, attribute_name))
         end


### PR DESCRIPTION
Reference:

https://github.com/plataformatec/simple_form/pull/997

DEPRECATION WARNING: judge method now accepts a `wrapper_options` argument. The method definition without the argument is deprecated and will be removed in the next Simple Form version. Change your code from:

def judge

to 

def judge(wrapper_options)